### PR TITLE
Support Laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "require": {
         "php": "^7.0",
         "graham-campbell/guzzle-factory": "^3.0",
-        "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*",
+        "illuminate/contracts": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
         "league/commonmark": "^0.17"
     },
     "require-dev": {


### PR DESCRIPTION
Laravel 5.6 was released yesterday. This PR allows the use of this package with Laravel 5.6

Also, please release a new version of this package (you can release a patch or a minor version) when you merge this PR, to avoid pulling `dev-master`. :wink:

:octocat: